### PR TITLE
Fix migration issue on PostgreSQL in migrate_188_to_189

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -14137,9 +14137,8 @@ migrate_188_to_189 ()
   /* Update the database. */
 
   /* The views result_overrides and results_autofp changed. */
-
+  sql ("DROP VIEW IF EXISTS result_new_severities;");
   sql ("DROP VIEW IF EXISTS result_overrides;");
-
   sql ("DROP VIEW IF EXISTS results_autofp;");
 
   /* Table result_nvts was added, with links in results and overrides. */


### PR DESCRIPTION
Caused by #742 where it seems that PostgreSQL behaves different then SQLite and throws the following message:

```
ERROR: cannot drop view result_overrides because other objects depend on it
DETAIL: view result_new_severities depends on view result_overrides
HINT: Use DROP ... CASCADE to drop the dependent objects too.
STATEMENT: DROP VIEW IF EXISTS result_overrides;
sql_exec_internal: PQexec failed: ERROR: cannot drop view result_overrides because other objects depend on it
                                    DETAIL: view result_new_severities depends on view result_overrides
                                    HINT: Use DROP ... CASCADE to drop the dependent objects too.
                                     (7)
sql_exec_internal: SQL: DROP VIEW IF EXISTS result_overrides;
sqlv: sql_exec_internal failed
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
